### PR TITLE
Use CF-gradle plugin 0.3.13.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
   // id "com.github.sherter.google-java-format" version "0.7.1"
 
   // Checker Framework pluggable type-checking
-  id "org.checkerframework" version "0.3.4"
+  id "org.checkerframework" version "0.3.13"
 }
 
 apply plugin: 'java-library'


### PR DESCRIPTION
The updated version will work with Checker Framework 3.x and Java 9+.