### PR TITLE
Don't apply CF plugin until sourceCompatibility is defined

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
   // id "com.github.sherter.google-java-format" version "0.7.1"
 
   // Checker Framework pluggable type-checking
-  id "org.checkerframework" version "0.3.22"
+  id "org.checkerframework" version "0.3.23" apply false
 }
 
 apply plugin: 'java-library'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
   // id "com.github.sherter.google-java-format" version "0.7.1"
 
   // Checker Framework pluggable type-checking
-  id "org.checkerframework" version "0.3.23" apply false
+  id "org.checkerframework" version "0.3.22" apply false
 }
 
 apply plugin: 'java-library'


### PR DESCRIPTION
I have no idea how this worked before. The CF plugin must be applied *after* the relevant Java plugin, which isn't applied until line 15.