### PR TITLE
Removed redundant suppress warnings

### DIFF
--- a/src/main/java/org/plumelib/util/CollectionsPlume.java
+++ b/src/main/java/org/plumelib/util/CollectionsPlume.java
@@ -129,7 +129,6 @@ public final class CollectionsPlume {
       return Arrays.equals((short[]) o1, (short[]) o2);
     }
 
-    @SuppressWarnings({"allcheckers:purity", "lock"}) // creates local state
     WeakIdentityPair<Object, Object> mypair = new WeakIdentityPair<>(o1, o2);
     if (deepEqualsUnderway.contains(mypair)) {
       return true;


### PR DESCRIPTION
This `@SuppressWarnings` is redundant because the method is already suppressing all purity and lock annotations. However, the Checker Framework doesn't issue any error, even though `-AwarnUnneededSuppressions` and `-Werror` are provided.