### PR TITLE
Add warning suppression.

### DIFF
--- a/src/main/java/org/plumelib/util/OrderedPairIterator.java
+++ b/src/main/java/org/plumelib/util/OrderedPairIterator.java
@@ -65,7 +65,6 @@ public class OrderedPairIterator<T extends @Nullable Object>
   public OrderedPairIterator(Iterator<T> itor1, Iterator<T> itor2) {
     this.itor1 = itor1;
     this.itor2 = itor2;
-    this.comparator = null;
     setnext1();
     setnext2();
   }

--- a/src/main/java/org/plumelib/util/OrderedPairIterator.java
+++ b/src/main/java/org/plumelib/util/OrderedPairIterator.java
@@ -65,6 +65,7 @@ public class OrderedPairIterator<T extends @Nullable Object>
   public OrderedPairIterator(Iterator<T> itor1, Iterator<T> itor2) {
     this.itor1 = itor1;
     this.itor2 = itor2;
+    this.comparator = null;
     setnext1();
     setnext2();
   }

--- a/src/main/java/org/plumelib/util/ToStringComparator.java
+++ b/src/main/java/org/plumelib/util/ToStringComparator.java
@@ -11,7 +11,7 @@ import java.util.Objects;
  * <p>It handles null values, sorting them according to their printed representation "null".
  */
 // Once https://github.com/typetools/checker-framework/issues/1970 is fixed, Comparator's type
-// argument should be marked as @Covariant and this should be declared as "extends
+// argument should be marked as @Contravariant and this should be declared as "extends
 // Comparator<@Nullable Object>".
 public class ToStringComparator implements Comparator<Object> {
   /** The unique instance (this class is a singleton). */
@@ -32,6 +32,7 @@ public class ToStringComparator implements Comparator<Object> {
    * @param in a set of elements
    * @return the elements, sorted according to {@code toString()}
    */
+  @SuppressWarnings("nullness:argument") // Comparator should be @Contravariant.
   public static <T> List<T> sorted(Iterable<T> in) {
     List<T> result = new ArrayList<T>();
     for (T object : in) {


### PR DESCRIPTION
~~I made this change because of the following error when using smillst/capture-conversion branch:~~

~~OrderedPairIterator.java:65: error: [initializedfields:contracts.postcondition] postcondition of <init> is not satisfied.
  public OrderedPairIterator(Iterator<T> itor1, Iterator<T> itor2) {
         ^
  found   : this is @InitializedFields({"itor1", "itor2"})
  required: this is @InitializedFields({"itor1", "itor2", "comparator"})~~


Merge with https://github.com/typetools/checker-framework/pull/3922 ("implement capture conversion").