### PR TITLE
Use the maven-publish plugin.

### DIFF
--- a/gradle/mavencentral.gradle
+++ b/gradle/mavencentral.gradle
@@ -11,87 +11,85 @@
 //  * Update ../CHANGELOG.md .
 //  * Save and stage changes.
 //  * Run in the top-level directory:
-//      ./gradlew clean uploadArchives && ./gradlew javadocWeb
+//      ./gradlew clean publish && ./gradlew javadocWeb
 //    or, to use a locally-built Checker Framework:
-//      ./gradlew -PcfLocal clean uploadArchives && ./gradlew -PcfLocal javadocWeb
+//      ./gradlew -PcfLocal clean publish && ./gradlew -PcfLocal javadocWeb
 //  * Browse to https://oss.sonatype.org/#stagingRepositories, complete the Maven Central release.
 //  * Add a git tag:
 //    VER=1.5.5 && git commit -m "Version $VER" && git push && git tag -a v$VER -m "Version $VER" && git push && git push --tags
 //  * Make a GitHub release. Go to the GitHub releases page, make a release, call it "plume-util 1.5.5", use text from ../CHANGELOG.md, attach the .jar file from ../build/libs/
 
 
-///////////////////////////////////////////////////////////////////////////
-/// Maven Central publishing
-/// (From http://central.sonatype.org/pages/gradle.html )
-
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-group = "org.plumelib"
-archivesBaseName = "plume-util"
-version = "1.5.5"
+group 'org.plumelib'
+version '1.5.5-SNAPSHOT'
 
-task javadocJar(type: Jar) {
-    classifier = 'javadoc'
-    from javadoc
-}
+final isSnapshot = version.contains('SNAPSHOT')
 
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 artifacts {
     archives javadocJar, sourcesJar
 }
 
-signing {
-    required { project.gradle.taskGraph.hasTask("uploadArchives") }
-    sign configurations.archives
-}
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
 
-uploadArchives {
-  doFirst {
-    repositories {
-      mavenDeployer {
-        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+            pom {
+                name = 'Plume-lib Util'
+                description = 'Utility libraries for Java.'
+                url = 'https://github.com/plume-lib/plume-util'
 
-        repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-          authentication(userName: ossrhUsername, password: ossrhPassword)
-        }
+                scm {
+                    connection = 'scm:git:git@github.com:plume-lib/plume-util.git'
+                    developerConnection = 'scm:git:git@github.com:plume-lib/plume-util.git'
+                    url = 'git@github.com:plume-lib/plume-util.git'
+                }
 
-        snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-          authentication(userName: ossrhUsername, password: ossrhPassword)
-        }
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://opensource.org/licenses/MIT'
+                    }
+                }
 
-        pom.project {
-          name 'Plume-lib Util'
-          packaging 'jar'
-          description 'Utility libraries for Java.'
-          url 'https://github.com/plume-lib/plume-util'
-
-          scm {
-            connection 'scm:git:git@github.com:plume-lib/plume-util.git'
-            developerConnection 'scm:git:git@github.com:plume-lib/plume-util.git'
-            url 'git@github.com:plume-lib/plume-util.git'
-          }
-
-          licenses {
-            license {
-              name 'MIT License'
-              url 'https://opensource.org/licenses/MIT'
+                developers {
+                    developer {
+                        id = 'mernst'
+                        name = 'Michael Ernst'
+                        email = 'mernst@alum.mit.edu'
+                    }
+                }
             }
-          }
-
-          developers {
-            developer {
-              id 'mernst'
-              name 'Michael Ernst'
-              email 'mernst@alum.mit.edu'
-            }
-          }
         }
-      }
     }
-  }
+    repositories {
+        repositories {
+            maven {
+                url = (isSnapshot
+                        ? project.properties.getOrDefault('SNAPSHOT_REPOSITORY_URL', 'https://oss.sonatype.org/content/repositories/snapshots/')
+                        : project.properties.getOrDefault('RELEASE_REPOSITORY_URL', 'https://oss.sonatype.org/service/local/staging/deploy/maven2/')
+                )
+                credentials {
+                    username = project.properties.get('ossrhUsername')
+                    password = project.properties.get('ossrhPassword')
+                }
+            }
+        }
+    }
 }
+
+signing {
+    // If anything about signing is misconfigured, fail loudly rather than quietly continuing with
+    // unsigned artifacts.
+    required = true
+    sign publishing.publications.maven
+}
+tasks.withType(Sign).configureEach { onlyIf { project.gradle.taskGraph.hasTask("publish") && !isSnapshot } }

--- a/gradle/mavencentral.gradle
+++ b/gradle/mavencentral.gradle
@@ -92,4 +92,5 @@ signing {
     required = true
     sign publishing.publications.maven
 }
-tasks.withType(Sign).configureEach { onlyIf { project.gradle.taskGraph.hasTask("publish") } }
+
+tasks.withType(Sign).configureEach { onlyIf { !isSnapshot } }

--- a/gradle/mavencentral.gradle
+++ b/gradle/mavencentral.gradle
@@ -24,7 +24,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 group 'org.plumelib'
-version '1.5.5-SNAPSHOT'
+version '1.5.6-SNAPSHOT'
 
 final isSnapshot = version.contains('SNAPSHOT')
 

--- a/gradle/mavencentral.gradle
+++ b/gradle/mavencentral.gradle
@@ -92,4 +92,4 @@ signing {
     required = true
     sign publishing.publications.maven
 }
-tasks.withType(Sign).configureEach { onlyIf { project.gradle.taskGraph.hasTask("publish") && !isSnapshot } }
+tasks.withType(Sign).configureEach { onlyIf { project.gradle.taskGraph.hasTask("publish") } }


### PR DESCRIPTION
I've changed the version number to `1.5.6-SNAPSHOT`, so you can test this without doing a full release.

To test run:
```
 ./gradlew clean publish
```

Then https://oss.sonatype.org/service/local/repositories/snapshots/content/org/plumelib/plume-util should show some listings.  Or you can browses for it https://oss.sonatype.org/#view-repositories;snapshots~browsestorage.

I can't test this because I don't have permission to upload plume-lib artifacts to oss.sonatype.org.   