### PR TITLE
Disable ErrorProne if using JDK 8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,13 +48,12 @@ test {
 /// Error Prone linter
 
 dependencies {
-  errorprone("com.google.errorprone:error_prone_core:2.10.0")
-  // JDK 8 support for Error Prone:
-  errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
+  errorprone("com.google.errorprone:error_prone_core:2.11.0")
 }
 tasks.withType(JavaCompile).configureEach {
   options.compilerArgs << "-Xlint:all,-processing" << "-Werror"
   options.errorprone {
+    enabled = JavaVersion.current() != JavaVersion.VERSION_1_8
     // Code copied from the JDK that we don't want to change gratuitously.
     excludedPaths = ".*/Weak.*Hash(er)?Map.java"
     disable(


### PR DESCRIPTION
An alternative to #191.  In this version the ErrorProne plugin is still applied to build files, but it is disabled if on JDK 8.  There's nothing wrong with #191, this is just a simpler way to disable ErrorProne when on JDK 8. 