### PR TITLE
Remove warning suppressions about constructors assigning fields

### DIFF
--- a/src/main/java/org/plumelib/util/ArrayMap.java
+++ b/src/main/java/org/plumelib/util/ArrayMap.java
@@ -105,7 +105,6 @@ public class ArrayMap<K extends @UnknownSignedness Object, V extends @UnknownSig
   @SuppressWarnings({
     "unchecked", // generic array cast
     "samelen:assignment", // initialization
-    "allcheckers:purity.not.sideeffectfree.assign.field" // initializes `this`
   })
   @SideEffectFree
   public ArrayMap(int initialCapacity) {
@@ -134,10 +133,7 @@ public class ArrayMap<K extends @UnknownSignedness Object, V extends @UnknownSig
    * @param values the values
    * @param size the number of used items in the arrays; may be less than their lengths
    */
-  @SuppressWarnings({
-    "samelen:assignment", // initialization
-    "allcheckers:purity.not.sideeffectfree.assign.field" // initializes `this`
-  })
+  @SuppressWarnings("samelen:assignment") // initialization
   @SideEffectFree
   private ArrayMap(
       K @SameLen("values") [] keys,
@@ -702,7 +698,6 @@ public class ArrayMap<K extends @UnknownSignedness Object, V extends @UnknownSig
     int initialSizeModificationCount;
 
     /** Creates a new ArrayMapIterator. */
-    @SuppressWarnings("allcheckers:purity") // initializes `this`
     @SideEffectFree
     ArrayMapIterator() {
       index = 0;

--- a/src/main/java/org/plumelib/util/ArraySet.java
+++ b/src/main/java/org/plumelib/util/ArraySet.java
@@ -358,7 +358,6 @@ public class ArraySet<E extends @UnknownSignedness Object> extends AbstractSet<E
     int initialSizeModificationCount;
 
     /** Creates a new ArraySetIterator. */
-    @SuppressWarnings("allcheckers:purity") // initializes `this`
     @SideEffectFree
     ArraySetIterator() {
       index = 0;

--- a/src/main/java/org/plumelib/util/IdentityArraySet.java
+++ b/src/main/java/org/plumelib/util/IdentityArraySet.java
@@ -272,7 +272,6 @@ public class IdentityArraySet<E extends @UnknownSignedness Object> extends Abstr
     int initialSizeModificationCount;
 
     /** Creates a new ArraySetIterator. */
-    @SuppressWarnings("allcheckers:purity") // initializes `this`
     @SideEffectFree
     ArraySetIterator() {
       index = 0;


### PR DESCRIPTION
CI fails until a snapshot release of CF is made, but that can't be done because one is already being used by a different pull request.