### PR TITLE
Avoid `NoSuchElementException` in `MathPlume.modulusStrictInt`

### DIFF
--- a/src/main/java/org/plumelib/util/MathPlume.java
+++ b/src/main/java/org/plumelib/util/MathPlume.java
@@ -989,6 +989,9 @@ public final class MathPlume {
     int lastNonstrict = 0; // arbitrary initial value
     if (nonstrictEnds) {
       firstNonstrict = itor.next().intValue();
+      if (!itor.hasNext()) {
+        return null;
+      }
     }
 
     int prev = itor.next().intValue();

--- a/src/test/java/org/plumelib/util/MathPlumeTest.java
+++ b/src/test/java/org/plumelib/util/MathPlumeTest.java
@@ -462,6 +462,7 @@ public final class MathPlumeTest {
 
     TestNonModulus testNonModulus = new TestNonModulus();
 
+    testNonModulus.checkStrict(new int[] {1}, null);
     testNonModulus.checkStrict(new int[] {1, 2, 3, 5, 6, 7, 9}, null);
     testNonModulus.checkStrict(new int[] {-1, 1, 2, 3, 5, 6, 7, 9}, new int[] {0, 4});
     testNonModulus.checkStrict(new int[] {1, 2, 3, 5, 6, 7, 9, 11}, null);


### PR DESCRIPTION
This patch brings the implementation of `MathPlume.modulusStrictInt` in-line with its specification; specifically:

```java
* @return an array of two integers (r,m) such that each number in NUMS is equal to r (mod m), or
* null if no such exists or the iterator contains fewer than 3 elements
```