### PR TITLE
Add locking annotation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   // implementation "com.google.errorprone:error_prone_annotations:${errorproneVersion}"
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
-  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
 }
 
 // To upload to Maven Central, see instructions in the file.
@@ -140,7 +140,7 @@ checkerFramework {
 // To use a snapshot version of the Checker Framework.
 if (true) {
   // TODO: Change the above test to false when CF is released.
-  ext.checkerFrameworkVersion = '3.44.0'
+  ext.checkerFrameworkVersion = '3.44.2-SNAPSHOT'
   dependencies {
     compileOnly "org.checkerframework:checker-qual:${checkerFrameworkVersion}"
     testCompileOnly "org.checkerframework:checker-qual:${checkerFrameworkVersion}"

--- a/src/main/java/org/plumelib/util/CollectionsPlume.java
+++ b/src/main/java/org/plumelib/util/CollectionsPlume.java
@@ -1244,7 +1244,7 @@ public final class CollectionsPlume {
     }
 
     @Override
-    public T nextElement() {
+    public T nextElement(@GuardSatisfied IteratorEnumeration<T> this) {
       return itor.next();
     }
   }


### PR DESCRIPTION
Merge together:
 * https://github.com/typetools/checker-framework/pull/6679
 * https://github.com/typetools/jdk/pull/215
 * https://github.com/typetools/jdk17u/pull/8
 * https://github.com/plume-lib/plume-util/pull/403

This pull request only succeeds together with that version of the Checker Framework.  So, probably make a snapshot release of the Checker Framework and use it in this pull request.